### PR TITLE
Adding message about Tampermonkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ Runs Waterloo's JobMine but enhances the functionality and navigation.
 ## Installation Steps
 
 - [Chrome](https://github.com/matthewn4444/jobmine-plus-extension/wiki/Chrome)
+    - *NOTE:* If you're using Chrome on Windows, make sure to read the installation steps carefully, or you risk losing all extension configurations when you close your browser, i.e. the list of which jobs you've read/seen, etc. 
 - [Firefox](https://github.com/matthewn4444/jobmine-plus-extension/wiki/Firefox)
 
+ 
 ## Features
 
 - Better navigation than normal JobMine (and better user interface)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Runs Waterloo's JobMine but enhances the functionality and navigation.
 ## Installation Steps
 
 - [Chrome](https://github.com/matthewn4444/jobmine-plus-extension/wiki/Chrome)
-    - *NOTE:* If you're using Chrome on Windows, make sure to read the installation steps carefully, or you risk losing all extension configurations when you close your browser, i.e. the list of which jobs you've read/seen, etc. 
+    - *NOTE:* If you're using Chrome on Windows, make sure to install [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo?hl=en) or you will risk *losing all JobMne plus stored data (i.e. preferences & read/seen job listings list) when you close your browser*
 - [Firefox](https://github.com/matthewn4444/jobmine-plus-extension/wiki/Firefox)
 
  

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Runs Waterloo's JobMine but enhances the functionality and navigation.
 ## Installation Steps
 
 - [Chrome](https://github.com/matthewn4444/jobmine-plus-extension/wiki/Chrome)
-    - *NOTE:* If you're using Chrome on Windows, make sure to install [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo?hl=en) or you will risk *losing all JobMne plus stored data (i.e. preferences & read/seen job listings list) when you close your browser*
+    - *NOTE:* If you're using Chrome on Windows, make sure to install [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo?hl=en) and import JobMine plus into Tampermonkey or you will risk **losing all JobMne plus stored data (i.e. preferences & read/seen job listings list) when you close your browser**
 - [Firefox](https://github.com/matthewn4444/jobmine-plus-extension/wiki/Firefox)
 
  


### PR DESCRIPTION
With the new Chrome security settings on Windows, if you close your browser, J+ is disabled and you can't activate it again. It took me a while to figure out that you can install Tampermonkey and use jobmine plus as a tampermonkey script rather than a native extension. This pull request is to add that notification in to inform people. You might also want to add a line or two about that in the chrome wiki page in the repo. 